### PR TITLE
Curl retries and longer timeout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,11 +92,11 @@ runs:
 
         RUSTC_VERSION_URL=https://raw.githubusercontent.com/${{ inputs.image }}/master/RUSTC_VERSION
         echo Fetching RUSTC_VERSION from $RUSTC_VERSION_URL
-        RUSTC_VERSION=`curl -s $RUSTC_VERSION_URL`
+        RUSTC_VERSION=`curl --max-time 10 --retry 5 --retry-delay 10 --retry-max-time 120 -s $RUSTC_VERSION_URL`
 
         SRTOOL_VERSION_URL=https://raw.githubusercontent.com/${{ inputs.image }}/master/VERSION
         echo Fetching SRTOOL_VERSION from $SRTOOL_VERSION_URL
-        SRTOOL_VERSION=`curl -s $SRTOOL_VERSION_URL`
+        SRTOOL_VERSION=`curl --max-time 10 --retry 5 --retry-delay 10 --retry-max-time 120 -s $SRTOOL_VERSION_URL`
 
         echo "RUSTC_VERSION=$RUSTC_VERSION" >> $GITHUB_ENV
         echo "SRTOOL_VERSION=$SRTOOL_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Release pipeline timed out here in curl. Increasing the timeout and retry now to preventing the whole pipeline from failing.   Options from https://stackoverflow.com/a/42873372

Failed CI:
https://github.com/polkadot-fellows/runtimes/actions/runs/18710137993/job/53366528094

<img width="1031" height="41" alt="Oct 22 Screenshot from Kianenigma" src="https://github.com/user-attachments/assets/4f3d9a51-868b-431f-a117-b2d275f7a92e" />

